### PR TITLE
Fix for the mega65 build on linux

### DIFF
--- a/xemu/ethertap.c
+++ b/xemu/ethertap.c
@@ -66,7 +66,8 @@ able to configure the device for itself, hmmm ...)  */
 #include <unistd.h>
 // net/if.h is not needed in my Linux box, but it seems it is needed on older Ubuntu versions at least, so ...
 #include <net/if.h>
-#include <linux/if.h>
+// disabling linux/if.h works for Ubuntu 14.04 / GCC 6.4.0
+//#include <linux/if.h>
 #include <linux/if_tun.h>
 #include <errno.h>
 


### PR DESCRIPTION
ubuntu 14.04, gcc 6.3.0.
This is just a proposed fix as it works for me, however it may
not work well for existing newer distros. There is some sort
of conflict between net/if.h and linux/if.h

Requires testing across various *nixes.