### PR TITLE
Add MSYS/MinGW Native Windows build

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Emulators running on Linux/Unix/Windows/OSX of various (mainly 8 bit) machines,
 including the Commodore LCD and Commodore 65 (and also some Mega65) as well.
 
-Written by (C)2016-2020 LGB (Gábor Lénárt) <lgblgblgb@gmail.com>
+Written by (C)2016-2019 LGB (Gábor Lénárt) <lgblgblgb@gmail.com>
 Source repository: https://github.com/lgblgblgb/xemu
 
 Xemu also contains code wasn't written by me. Please read this page to get to
@@ -188,6 +188,43 @@ Run one of them, like (the Commodore LCD emulator in this case):
 For building binary (exe) for Windows, you still need a UNIX-like environment
 (in theory WSL - Windows Subsystem for Linux - should be enough)  for the
 compilation, with cross-compiler and SDL2 MinGW cross platform suite installed.
+
+#### MSYS2 native build
+
+An easy way to build xemu under Windows is to use the  MSYS2 package which includes
+a full MinGW compiler, associated headers, tools , and a nice package management utility
+for easy installation of required components: Pacman, popular in ArchLinux-based distros.
+
+The following steps are based on a Windows-10 x64 system.
+
+* Download the executable installer in https://www.msys2.org for x86-64 architecture.
+* Install on the default location.
+* Execute the MSYS2 MinGW 64bit system prompt at installation end, or by looking into your Start Menu.
+* In the command prompt, ensure you have the latest repositories by doing:
+
+```
+pacman -Syu
+```
+Restart the prompt if needed, and finish installing remaining packages with:
+
+```
+pacman -Su
+```
+
+Now we can install the GCC compiler and required packages to build xemu with one command call:
+
+```
+pacman -S base-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-SDL2 
+```
+
+Build the native Windows executables by issuing:
+```
+make ARCH=nativewin
+```
+
+
+
+#### Alternative method (Cross-compilation)
 
 For Ubuntu (and probably other DEB based distros, this also includes of course
 WSL if Ubuntu is used as the guest) you can install mingw by:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Emulators running on Linux/Unix/Windows/OSX of various (mainly 8 bit) machines,
 including the Commodore LCD and Commodore 65 (and also some Mega65) as well.
 
-Written by (C)2016-2019 LGB (Gábor Lénárt) <lgblgblgb@gmail.com>
+Written by (C)2016-2020 LGB (Gábor Lénárt) <lgblgblgb@gmail.com>
 Source repository: https://github.com/lgblgblgb/xemu
 
 Xemu also contains code wasn't written by me. Please read this page to get to
@@ -214,7 +214,7 @@ pacman -Su
 Now we can install the GCC compiler and required packages to build xemu with one command call:
 
 ```
-pacman -S base-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-SDL2 
+pacman -S make mingw-w64-x86_64-toolchain mingw-w64-x86_64-SDL2 
 ```
 
 Build the native Windows executables by issuing:
@@ -222,7 +222,7 @@ Build the native Windows executables by issuing:
 make ARCH=nativewin
 ```
 
-
+You can find the executables, with '.nativewin' extension, in the 'build/bin' directory.
 
 #### Alternative method (Cross-compilation)
 

--- a/build/Makefile.nativewin
+++ b/build/Makefile.nativewin
@@ -1,0 +1,31 @@
+## Collection of *simple* emulators of some 8 bits machines using SDL2 library,
+## including the Commodore LCD and Commodore 65 too.
+##
+## Copyright (C)2016,2017 LGB (Gábor Lénárt) <lgblgblgb@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+# WARNING: the ::CFLAGS:: and ::LDFLAGS:: part are here for INTENT, do not alter or remove!
+# It will be replaced in Makefile.common with the right settings!
+
+ARCH_DESC	= "Native Windows/MinGW"
+PREFIX		= /usr/local
+BINDIR		= $(PREFIX)/bin
+DATADIR		= $(PREFIX)/lib/xemu
+CC		= gcc
+STRIP		= strip
+GENOPTS		= -std=gnu11 -Ofast -fno-common -falign-functions=16 -falign-loops=16 -ffast-math
+CFLAGS_ARCH	= $(GENOPTS) -Wall -pipe ::CFLAGS::
+LDFLAGS_ARCH	= $(GENOPTS) ::LDFLAGS::

--- a/build/system-config-settings.txt
+++ b/build/system-config-settings.txt
@@ -9,7 +9,9 @@ win32#sdl2#dll#			echo "`$SDL2_CONFIG_WIN32 --prefix`/$SDL2_DLL_RELPATH"
 win64#sdl2#dll#			echo "`$SDL2_CONFIG_WIN64 --prefix`/$SDL2_DLL_RELPATH"
 
 native#sdl2#cflags#		$SDL2_CONFIG_NATIVE --cflags && echo " -D HAVE_SDL2"
-native#sdl2#ldflags#		$SDL2_CONFIG_NATIVE --libs
+native#sdl2#ldflags#	$SDL2_CONFIG_NATIVE --libs
+nativewin#sdl2#cflags#	$SDL2_CONFIG_NATIVE --cflags && echo " -D HAVE_SDL2"
+nativewin#sdl2#ldflags#	$SDL2_CONFIG_NATIVE --libs
 osx#sdl2#cflags#		$SDL2_CONFIG_OSX    --cflags && echo " -D HAVE_SDL2"
 osx#sdl2#ldflags#		$SDL2_CONFIG_OSX    --libs
 win32#sdl2#cflags#		$SDL2_CONFIG_WIN32  --cflags && echo " -D HAVE_SDL2"
@@ -21,6 +23,7 @@ html#sdl2#ldflags#		echo " -s USE_SDL=2"
 
 ;native#math#cflags#
 native#math#ldflags#		echo " -lm"
+nativewin#math#ldflags	echo " -lm"
 ;osx#math#cflags#
 osx#math#ldflags#		echo " -lm"
 ;win32#math#cflags#
@@ -60,5 +63,6 @@ win32#socketapi#cflags#		echo " -D HAVE_SOCKET_OS_API"
 win32#socketapi#ldflags#	echo " -lwsock32"
 win64#socketapi#cflags#		echo " -D HAVE_SOCKET_OS_API"
 win64#socketapi#ldflags#	echo " -lwsock32"
+nativewin#socketapi#ldflags#    echo " -lwsock32"
 ;html#socketapi#cflags#
 ;html#socketapi#ldflags#


### PR DESCRIPTION
Currently xemu can make Windows binaries from "real Linux/UNIX" by cross-compilation.
By using MSYS2/MinGW environment, users can build native binaries (both in 32 and 64 bit flavors) for Windows systems without booting Linux or Windows Subsystem for Linux.
Note that building under WSL should be similar.

Requirements are MSYS2/MinGW package found at http://www.msys2.org/.

Documentation in README added.