### PR TITLE
Update 200818

### DIFF
--- a/targets/mega65/mega65.c
+++ b/targets/mega65/mega65.c
@@ -62,6 +62,8 @@ static int cpu_cycles_per_step = 100; 	// some init value, will be overriden, bu
 static int force_external_rom = 0;
 static int force_upload_fonts = 0;
 
+Uint8 last_dd00_bits = 3; // Bank 0 
+
 void cpu65_illegal_opcode_callback ( void )
 {
 	// FIXME: implement this, it won't be ever seen now, as not even switch to 6502 NMOS persona is done yet ...
@@ -172,11 +174,18 @@ static void cia2_out_a ( Uint8 data )
 {   
 	if (REG_HOTREG && !REG_CRAM2K)
 	{
+		// Bank select
+
+		data &= (cia2.DDRA & 3); // Mask bank bits through CIA DDR register bits
+
 		REG_SCRNPTR_B1 = (~data << 6) | (REG_SCRNPTR_B1 & 0x3F);
 		REG_CHARPTR_B1 = (~data << 6) | (REG_CHARPTR_B1 & 0x3F);
 		REG_SPRPTR_B1  = (~data << 6) | (REG_SPRPTR_B1 & 0x3F);
+
+		last_dd00_bits = data;
+		DEBUGPRINT("VIC2: (hotreg)Wrote to $DD00: $%02x screen=$%08x char=$%08x spr=$%08x" NL, data, SCREEN_ADDR, CHARSET_ADDR, SPRITE_POINTER_ADDR);
 	}
-	DEBUG("VIC2: Wrote to $DD00: $%08x" NL, data);
+
 }
 
 

--- a/targets/mega65/mega65.c
+++ b/targets/mega65/mega65.c
@@ -62,7 +62,6 @@ static int cpu_cycles_per_step = 100; 	// some init value, will be overriden, bu
 static int force_external_rom = 0;
 static int force_upload_fonts = 0;
 
-
 void cpu65_illegal_opcode_callback ( void )
 {
 	// FIXME: implement this, it won't be ever seen now, as not even switch to 6502 NMOS persona is done yet ...
@@ -462,7 +461,6 @@ static void update_emulator ( void )
 //	}
 }
 
-
 #ifdef HAS_UARTMON_SUPPORT
 void m65mon_show_regs ( void )
 {
@@ -690,7 +688,7 @@ int main ( int argc, char **argv )
 	if (xemu_post_init(
 		TARGET_DESC APP_DESC_APPEND,	// window title
 		1,				// resizable window
-		SCREEN_WIDTH, SCREEN_HEIGHT,	// texture sizes
+		SCREEN_WIDTH, PHYSICAL_RASTERS_DEFAULT,	// texture sizes
 		SCREEN_WIDTH, SCREEN_HEIGHT,// logical size (used with keeping aspect ratio by the SDL render stuffs)
 		SCREEN_WIDTH, SCREEN_HEIGHT,// window size
 		SCREEN_FORMAT,			// pixel format

--- a/targets/mega65/mega65.h
+++ b/targets/mega65/mega65.h
@@ -36,7 +36,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
    You can try RENDER_SCALE_QUALITY though with values 0, 1, 2 */
 #define SCREEN_FORMAT           SDL_PIXELFORMAT_ARGB8888
 #define USE_LOCKED_TEXTURE	1
-#define RENDER_SCALE_QUALITY	1
+#define RENDER_SCALE_QUALITY	2
 
 
 // Default fast clock of M65, in MHz (can be overriden with CLI switch)

--- a/targets/mega65/mega65.h
+++ b/targets/mega65/mega65.h
@@ -74,5 +74,6 @@ extern int  refill_c65_rom_from_preinit_cache ( void );
 
 extern int newhack;
 extern unsigned int frames_total_counter;
+extern Uint8 last_dd00_bits;
 
 #endif

--- a/targets/mega65/vic4.c
+++ b/targets/mega65/vic4.c
@@ -3,15 +3,6 @@
    Copyright (C)2016,2017 LGB (Gábor Lénárt) <lgblgblgb@gmail.com>
    Copyright (C)2020 Hernán Di Pietro <hernan.di.pietro@gmail.com>
 
-   This is the VIC-IV "emulation". Currently it does one-frame-at-once
-   kind of horrible work, and only a subset of VIC2 and VIC3 knowledge
-   is implemented, with some light VIC-IV features, to be able to "boot"
-   of Mega-65 with standard configuration (kickstart, SD-card).
-   Some of the missing features (VIC-2/3): hardware attributes,
-   DAT, sprites, screen positioning, H1280 mode, V400 mode, interlace,
-   chroma killer, VIC2 MCM, ECM, 38/24 columns mode, border.
-   VIC-4: almost everything :(
-
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
@@ -66,7 +57,7 @@ static int border_x_left= 0;			 // Side border left
 static int border_x_right= 0;			 // Side border right
 static int xcounter = 0, ycounter = 0;   // video counters
 static int frame_counter = 0;
-static int vicii_first_raster = 0;
+
 static int char_row = 0, display_row = 0;
 static Uint8 bg_pixel_state[1024]; 		// See FOREGROUND_PIXEL and BACKGROUND_PIXEL constants
 static Uint8* screen_ram_current_ptr = NULL;
@@ -77,15 +68,20 @@ static int warn_ctrl_b_lo = 1;
 static int enable_bg_paint = 1;
 static int display_row_count = 0;
 
+static int max_rasters = PHYSICAL_RASTERS_DEFAULT;
+static int visible_area_height = SCREEN_HEIGHT_VISIBLE_DEFAULT;
+static int vicii_first_raster = 7;	// Default for NTSC
+
 // VIC-IV Modeline Parameters
 // ----------------------------------------------------
+#define DISPLAY_HEIGHT			((max_rasters-1)-20)
 #define TEXT_HEIGHT_200  		400
 #define TEXT_HEIGHT_400  		400
 #define CHARGEN_Y_SCALE_200 	2
 #define CHARGEN_Y_SCALE_400 	1
 #define chargen_y_pixels 		0
-#define TOP_BORDERS_HEIGHT_200 	(SCREEN_HEIGHT - TEXT_HEIGHT_200)
-#define TOP_BORDERS_HEIGHT_400 	(SCREEN_HEIGHT - TEXT_HEIGHT_400)
+#define TOP_BORDERS_HEIGHT_200 	(DISPLAY_HEIGHT - TEXT_HEIGHT_200)
+#define TOP_BORDERS_HEIGHT_400 	(DISPLAY_HEIGHT - TEXT_HEIGHT_400)
 #define SINGLE_TOP_BORDER_200 	(TOP_BORDERS_HEIGHT_200 >> 1)
 #define SINGLE_TOP_BORDER_400 	(TOP_BORDERS_HEIGHT_400 >> 1)
 
@@ -190,11 +186,26 @@ void vic_init ( void )
 	DEBUG("VIC4: has been initialized." NL);
 }
 
+
+// This function allows to switch between NTSC/PAL on-the-fly (NTSC = 1. PAL = 0)
+void vic4_switch_display_mode(int ntsc)
+{
+	DEBUGPRINT("VIC: switch_display_mode NTSC=%d" NL, ntsc);
+	xemu_change_display_mode(SCREEN_WIDTH, ntsc ? PHYSICAL_RASTERS_NTSC : PHYSICAL_RASTERS_PAL,	// texture sizes
+		SCREEN_WIDTH, SCREEN_HEIGHT,// logical size (used with keeping aspect ratio by the SDL render stuffs)
+		SCREEN_WIDTH, SCREEN_HEIGHT,// window size
+		SCREEN_FORMAT,
+		USE_LOCKED_TEXTURE);
+
+	vic4_open_frame_access();
+}
+
+
 void vic4_open_frame_access()
 {
 	int tail_sdl;
 	current_pixel = pixel_start = xemu_start_pixel_buffer_access(&tail_sdl);
-	pixel_end = current_pixel + (SCREEN_WIDTH * SCREEN_HEIGHT);
+	pixel_end = current_pixel + (SCREEN_WIDTH * max_rasters);
 	if (tail_sdl)
 		FATAL("tail_sdl is not zero!");
 }
@@ -231,6 +242,14 @@ static void vic4_check_raster_interrupt ( void )
 inline static void vic4_calculate_char_x_step()
 {
 	char_x_step = (REG_CHARXSCALE / 120.0f) / (REG_H640 ? 1 : 2);
+}
+
+static void vic4_reset_display_counters()
+{
+	xcounter = 0;
+	display_row = 0;
+	char_row = 0;
+	ycounter = 0;
 }
 
 static void vic4_update_sideborder_dimensions()
@@ -297,34 +316,34 @@ static void vic4_interpret_legacy_mode_registers()
 		if (REG_RSEL) // 25-row
 		{
 			SET_BORDER_Y_TOP(RASTER_CORRECTION + SINGLE_TOP_BORDER_200 - (2 * vicii_first_raster));
-			SET_BORDER_Y_BOTTOM(RASTER_CORRECTION + SCREEN_HEIGHT - SINGLE_TOP_BORDER_200 - (2 * vicii_first_raster) - 1);
+			SET_BORDER_Y_BOTTOM(RASTER_CORRECTION + DISPLAY_HEIGHT - SINGLE_TOP_BORDER_200 - (2 * vicii_first_raster) - 1);
 			display_row_count = 25;
 		}
 		else
 		{
 			SET_BORDER_Y_TOP(RASTER_CORRECTION + SINGLE_TOP_BORDER_200 - (2 * vicii_first_raster) + 8);
-			SET_BORDER_Y_BOTTOM(RASTER_CORRECTION + SCREEN_HEIGHT - (2 * vicii_first_raster) - SINGLE_TOP_BORDER_200 - 7);
+			SET_BORDER_Y_BOTTOM(RASTER_CORRECTION + DISPLAY_HEIGHT - (2 * vicii_first_raster) - SINGLE_TOP_BORDER_200 - 7);
 			display_row_count = 24;
 		}
 
-		SET_CHARGEN_Y_START(RASTER_CORRECTION + SINGLE_TOP_BORDER_200 + (2 * vicii_first_raster) - 6 + REG_VIC2_YSCROLL * 2);
+		SET_CHARGEN_Y_START(RASTER_CORRECTION + SINGLE_TOP_BORDER_200 - (2 * vicii_first_raster) - 6 + REG_VIC2_YSCROLL * 2);
 	}
 	else // V400
 	{
 		if (REG_RSEL) // 25-line+V400
 		{
 			SET_BORDER_Y_TOP(RASTER_CORRECTION + SINGLE_TOP_BORDER_400 - (2 * vicii_first_raster));
-			SET_BORDER_Y_BOTTOM(RASTER_CORRECTION + SCREEN_HEIGHT - SINGLE_TOP_BORDER_400 - (2 * vicii_first_raster) - 1);
+			SET_BORDER_Y_BOTTOM(RASTER_CORRECTION + DISPLAY_HEIGHT - SINGLE_TOP_BORDER_400 - (2 * vicii_first_raster) - 1);
 			display_row_count = 25*2;
 		}
 		else
 		{
 			SET_BORDER_Y_TOP(RASTER_CORRECTION + SINGLE_TOP_BORDER_400 - (2 * vicii_first_raster) + 8);
-			SET_BORDER_Y_BOTTOM(RASTER_CORRECTION + SCREEN_HEIGHT - (2 * vicii_first_raster) - SINGLE_TOP_BORDER_200 - 7);
+			SET_BORDER_Y_BOTTOM(RASTER_CORRECTION + DISPLAY_HEIGHT - (2 * vicii_first_raster) - SINGLE_TOP_BORDER_200 - 7);
 			display_row_count = 24*2;
 		}
 
-		SET_CHARGEN_Y_START(RASTER_CORRECTION + SINGLE_TOP_BORDER_400 + (2 * vicii_first_raster) - 6 + (REG_VIC2_YSCROLL * 2));
+		SET_CHARGEN_Y_START(RASTER_CORRECTION + SINGLE_TOP_BORDER_400 - (2 * vicii_first_raster) - 6 + (REG_VIC2_YSCROLL * 2));
 	}
 
 	Uint8 width = REG_H640 ? 80 : 40;
@@ -344,9 +363,10 @@ static void vic4_interpret_legacy_mode_registers()
 	vic_registers[0x6E] &= 128;
 
 	SET_COLORRAM_BASE(0);
-	DEBUGPRINT("VIC4: 16bit=%d, chrcount=%d, charstep=%d bytes, charscale=%d, border yt=%d, yb=%d, xl=%d, xr=%d, textxpos=%d, textypos=%d,"
+	DEBUGPRINT("VIC4: 16bit=%d, chrcount=%d, charstep=%d bytes, charscale=%d, vic_ii_first_raster=%d, "
+	          "border yt=%d, yb=%d, xl=%d, xr=%d, textxpos=%d, textypos=%d,"
 	          "screen_ram=$%06x, charset/bitmap=$%06x, sprite=$%06x" NL, REG_16BITCHARSET ,   REG_CHRCOUNT,CHARSTEP_BYTES,REG_CHARXSCALE,
-		BORDER_Y_TOP, BORDER_Y_BOTTOM, border_x_left, border_x_right, CHARGEN_X_START, CHARGEN_Y_START,
+		vicii_first_raster, BORDER_Y_TOP, BORDER_Y_BOTTOM, border_x_left, border_x_right, CHARGEN_X_START, CHARGEN_Y_START,
 		SCREEN_ADDR, CHARSET_ADDR, SPRITE_POINTER_ADDR);
 }
 
@@ -474,7 +494,7 @@ void vic_write_reg ( unsigned int addr, Uint8 data )
 			} while(0);
 			break;
 		CASE_VIC_2(0x30):	// this register is _SPECIAL_, and exists only in VIC-II (C64) I/O mode: C128-style "2MHz fast" mode ...
-			DEBUGPRINT("WRITE 0xD030: $%02x" NL, data);
+			DEBUGPRINT("VIC: Write 0xD030: $%02x" NL, data);
 			c128_d030_reg = data;
 			machine_set_speed(0);
 			return;		// it IS important to have return here, since it's not a "real" VIC-4 mode register's view in another mode!!
@@ -518,7 +538,7 @@ void vic_write_reg ( unsigned int addr, Uint8 data )
 			return;				// since we DID the write, it's OK to return here and not using "break"
 		CASE_VIC_4(0x55): CASE_VIC_4(0x56): CASE_VIC_4(0x57): break; 
 		CASE_VIC_4(0x58): CASE_VIC_4(0x59): 
-			DEBUGPRINT("WRITE $%04x CHARSTEP: $%02x" NL, addr, data);
+			DEBUGPRINT("VIC: Write $%04x CHARSTEP: $%02x" NL, addr, data);
 			break;
 		CASE_VIC_4(0x5A): 
 			//DEBUGPRINT("WRITE $%04x CHARXSCALE: $%02x" NL, addr, data);
@@ -532,19 +552,19 @@ void vic_write_reg ( unsigned int addr, Uint8 data )
 			break;
 
 		CASE_VIC_4(0x5D): 
-			DEBUGPRINT("WRITE $%04x SIDEBORDER/HOTREG: $%02x" NL, addr, data);
+			DEBUGPRINT("VIC: Write $%04x SIDEBORDER/HOTREG: $%02x" NL, addr, data);
 
 			if((vic_registers[0x5D] & 0x1F) ^ (data & 0x1F))  // sideborder MSB (0..5) modified ? 
 				vic4_sideborder_touched = 1;
 			break;		
 		
 		CASE_VIC_4(0x5E): 
-			DEBUGPRINT("WRITE $%04x CHARCOUNT: $%02x" NL, addr, data);
+			DEBUGPRINT("VIC: Write $%04x CHARCOUNT: $%02x" NL, addr, data);
 			break;
 		CASE_VIC_4(0x5F): 
 			break;
 		CASE_VIC_4(0x60): CASE_VIC_4(0x61): CASE_VIC_4(0x62): CASE_VIC_4(0x63):
-			DEBUGPRINT("WRITE 0xD0%02x: $%02x" NL, addr, data);
+			DEBUGPRINT("VIC: Write 0xD0%02x: $%02x" NL, addr, data);
 			break;
 		CASE_VIC_4(0x64):
 		CASE_VIC_4(0x65): CASE_VIC_4(0x66): CASE_VIC_4(0x67): /*CASE_VIC_4(0x68): CASE_VIC_4(0x69): CASE_VIC_4(0x6A):*/ CASE_VIC_4(0x6B): /*CASE_VIC_4(0x6C):
@@ -557,24 +577,42 @@ void vic_write_reg ( unsigned int addr, Uint8 data )
 			break;
 		CASE_VIC_4(0x6C): CASE_VIC_4(0x6D): CASE_VIC_4(0x6E):
 			vic_registers[addr & 0x7F] = data;
-			if (SPRITE_POINTER_ADDR > 384*1024) {
-				DEBUGPRINT("WARNING !!! : SPRITE_POINTER_ADDR at $%08X exceeds 384K chip RAM!!!!  Current behavior is undefined." NL, SPRITE_POINTER_ADDR);
-			}
+			// if (SPRITE_POINTER_ADDR > 384*1024) {
+			// 	DEBUGPRINT("WARNING !!! : SPRITE_POINTER_ADDR at $%08X exceeds 384K chip RAM!!!!  Current behavior is undefined." NL, SPRITE_POINTER_ADDR);
+			// }
 
-			DEBUGPRINT("SPRPTRADR/SPRPTRBNK Modified. Sprite Data Pointers now: " NL);
+			// DEBUGPRINT("SPRPTRADR/SPRPTRBNK Modified. Sprite Data Pointers now: " NL);
 
-			for (int i = 0; i < 8; ++i) {
-				const Uint8 *sprite_data_pointer =  main_ram + SPRITE_POINTER_ADDR + i * ((SPRITE_16BITPOINTER >> 7) + 1);
-				const Uint32 dataptr = SPRITE_16BITPOINTER ? 64 * ( ((*(sprite_data_pointer+1) << 8)) + (*(sprite_data_pointer))) : 64 * (*sprite_data_pointer);
-				DEBUGPRINT("Sprite #%d data @ $%08X %s" NL , i, dataptr, dataptr > 384*1024 ? "!!! OUT OF 384K main RAM !!!" : "");
-			}
+			// for (int i = 0; i < 8; ++i) {
+			// 	const Uint8 *sprite_data_pointer =  main_ram + SPRITE_POINTER_ADDR + i * ((SPRITE_16BITPOINTER >> 7) + 1);
+			// 	const Uint32 dataptr = SPRITE_16BITPOINTER ? 64 * ( ((*(sprite_data_pointer+1) << 8)) + (*(sprite_data_pointer))) : 64 * (*sprite_data_pointer);
+			// 	DEBUGPRINT("Sprite #%d data @ $%08X %s" NL , i, dataptr, dataptr > 384*1024 ? "!!! OUT OF 384K main RAM !!!" : "");
+			// }
 
 			break;
 		CASE_VIC_4(0x6F):
-			vicii_first_raster  = data & 0x1F;
+			// Trigger video mode change.
+
+			max_rasters = data & 0x80 ? PHYSICAL_RASTERS_NTSC : PHYSICAL_RASTERS_PAL;
+			visible_area_height = data & 0x80 ? SCREEN_HEIGHT_VISIBLE_NTSC : SCREEN_HEIGHT_VISIBLE_PAL;
+			
+			if ((vic_registers[0x6F] & 0x80) ^ (data & 0x80))
+			{
+				// Change video mode
+				vic4_reset_display_counters();
+				vic4_switch_display_mode(data & 0x80);
+			}
+		
+			vicii_first_raster = data & 0x1F;
+
 			if (!in_hypervisor)
+			{
 				vic4_sideborder_touched = 1;
-			break;
+				vic4_interpret_legacy_mode_registers();
+			}
+
+			break;			
+
 		CASE_VIC_4(0x70):	// VIC-IV palette selection register
 			palette		= ((data & 0x03) << 8) + vic_palettes;
 			spritepalette	= ((data & 0x0C) << 6) + vic_palettes;
@@ -605,7 +643,7 @@ void vic_write_reg ( unsigned int addr, Uint8 data )
 	{
 		if (vic_hotreg_touched)
 		{
-			DEBUGPRINT("vic_hotreg_touched triggered (WRITE $D0%02x, $%02x)" NL, addr & 0x7F, data );
+			DEBUGPRINT("VIC: vic_hotreg_touched triggered (WRITE $D0%02x, $%02x)" NL, addr & 0x7F, data );
 			vic4_interpret_legacy_mode_registers();
 			vic_hotreg_touched = 0;
 			vic4_sideborder_touched = 0;
@@ -613,7 +651,7 @@ void vic_write_reg ( unsigned int addr, Uint8 data )
 
 		if (vic4_sideborder_touched)
 		{
-			DEBUGPRINT("vic4_sideborder_touched triggered (WRITE $D0%02x, $%02x)" NL, addr & 0x7F, data );
+			DEBUGPRINT("VIC: vic4_sideborder_touched triggered (WRITE $D0%02x, $%02x)" NL, addr & 0x7F, data );
 			
 			vic4_update_sideborder_dimensions();
 			vic4_sideborder_touched = 0;
@@ -893,10 +931,10 @@ static void vic4_do_sprites()
 					64 * ((*(sprite_data_pointer + 1) << 8) | (*sprite_data_pointer))
 					: 64 * (*sprite_data_pointer);
 
-				if (sprite_data_addr > 384*1024)
-				{
-					DEBUGPRINT("Sprite %d data at $%08X (out of 384K chip RAM!) -- Behaviour is undefined!" NL, sprnum, sprite_data_addr);
-				}
+				// if (sprite_data_addr > 384*1024)
+				// {
+				// 	DEBUGPRINT("VIC: Sprite %d data at $%08X (out of 384K chip RAM!) -- Behaviour is undefined!" NL, sprnum, sprite_data_addr);
+				// }
 
 				const Uint8 *sprite_data = main_ram + sprite_data_addr;
 				Uint8 *row_data = sprite_data + widthBytes * sprite_row_in_raster;
@@ -1169,6 +1207,7 @@ int vic4_render_scanline()
 	}
 	else
 	{
+		
 		// Top and bottom borders
 
 		if (ycounter < BORDER_Y_TOP || ycounter >= BORDER_Y_BOTTOM || !REG_DISPLAYENABLE)
@@ -1178,32 +1217,31 @@ int vic4_render_scanline()
 		}
 		else
 		{
-			// Render visible display first and render side-borders later to cover X-displaced 
+			// Render visible display first and render side-borders later to cover X-displaced
 			// character generator if needed.
-			
+
 			xcounter += border_x_left;
 			current_pixel += border_x_left;
 
 			vic4_render_char_raster();
-			vic4_do_sprites();			
+			vic4_do_sprites();
 
-			for (Uint32* p = pixel_raster_start; p < pixel_raster_start + border_x_left; ++p)
+			for (Uint32 *p = pixel_raster_start; p < pixel_raster_start + border_x_left; ++p)
 				*p = palette[REG_BORDER_COLOR & 0xF];
 
-			for (Uint32* p = current_pixel; p < current_pixel + border_x_right; ++p)
+			for (Uint32 *p = current_pixel; p < current_pixel + border_x_right; ++p)
 				*p = palette[REG_BORDER_COLOR & 0xF];
 		}
 	}
 	ycounter++;
-	
+
 	// End of frame?
-	if (ycounter == SCREEN_HEIGHT)
+	if (ycounter == max_rasters)    
 	{
-		display_row = 0;
-		char_row = 0;
+		vic4_reset_display_counters();
+		
 		screen_ram_current_ptr = main_ram + SCREEN_ADDR;
 		colour_ram_current_ptr = colour_ram;
-		ycounter = 0;
 		frame_counter++;
 		if (frame_counter == VIC4_BLINK_INTERVAL)
 		{

--- a/targets/mega65/vic4.c
+++ b/targets/mega65/vic4.c
@@ -693,6 +693,7 @@ Uint8 vic_read_reg ( int unsigned addr )
 		CASE_VIC_ALL(0x17):	// sprite-Y expansion
 			break;
 		CASE_VIC_ALL(0x18):	// memory pointers
+			result |= 1;
 			// Always mapped to VIC-IV extended "precise" registers
 			// result = ((REG_SCRNPTR_B1 & 60) << 2) | ((REG_CHARPTR_B1 & 60) >> 2);
 			// DEBUGPRINT("READ 0x81: $%02x" NL, result);
@@ -943,10 +944,10 @@ static void vic4_do_sprites()
 				const Uint8 *sprite_data = main_ram + sprite_data_addr;
 				const Uint8 *row_data = sprite_data + widthBytes * sprite_row_in_raster;
 				int xscale = (REG_SPR640 ? 1 : 2) * (SPRITE_HORZ_2X(sprnum) ? 2 : 1);
-				if (SPRITE_16COLOR(sprnum))
-					vic4_draw_sprite_row_16color(sprnum, x_display_pos, row_data, xscale);
-				else if (SPRITE_MULTICOLOR(sprnum))
+				if (SPRITE_MULTICOLOR(sprnum))
 					vic4_draw_sprite_row_multicolor(sprnum, x_display_pos, row_data, xscale);
+				else if (SPRITE_16COLOR(sprnum))
+					vic4_draw_sprite_row_16color(sprnum, x_display_pos, row_data, xscale);
 				else
 					vic4_draw_sprite_row_mono(sprnum, x_display_pos, row_data, xscale);
 			}

--- a/targets/mega65/vic4.c
+++ b/targets/mega65/vic4.c
@@ -939,7 +939,7 @@ static void vic4_do_sprites()
 					64 * ((*(sprite_data_pointer + 1) << 8) | (*sprite_data_pointer))
 					: ((64 * (*sprite_data_pointer)) | ( ((~last_dd00_bits) & 0x3)) << 14);
 
-				DEBUGPRINT("VIC: Sprite %d data at $%08X " NL, sprnum, sprite_data_addr);
+				//DEBUGPRINT("VIC: Sprite %d data at $%08X " NL, sprnum, sprite_data_addr);
 				const Uint8 *sprite_data = main_ram + sprite_data_addr;
 				const Uint8 *row_data = sprite_data + widthBytes * sprite_row_in_raster;
 				int xscale = (REG_SPR640 ? 1 : 2) * (SPRITE_HORZ_2X(sprnum) ? 2 : 1);

--- a/targets/mega65/vic4.h
+++ b/targets/mega65/vic4.h
@@ -41,10 +41,11 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 #define SCREEN_HEIGHT_VISIBLE_PAL     576
 #define PHYSICAL_RASTERS_NTSC         526
 #define PHYSICAL_RASTERS_PAL          624
-
-#define FRAME_H_FRONT                  0
-#define RASTER_CORRECTION              3
-#define VIC4_BLINK_INTERVAL            25
+#define NTSC_RATIO                    PHYSICAL_RASTERS_NTSC / float(SCREEN_WIDTH)
+#define PAL_RATIO                     PHYSICAL_RASTERS_PAL  / float(SCREEN_WIDTH)
+#define FRAME_H_FRONT                 0
+#define RASTER_CORRECTION             3
+#define VIC4_BLINK_INTERVAL           25
 
 // Register defines 
 // 

--- a/targets/mega65/vic4.h
+++ b/targets/mega65/vic4.h
@@ -143,7 +143,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 #define SPRITE_VERT_2X(n)    (vic_registers[0x17] & (1 << (n)))
 #define SPRITE_MULTICOLOR(n) (vic_registers[0x1C] & (1 << (n)))
 #define SPRITE_16COLOR(n)    (vic_registers[0x6B] & (1 << (n)))
-#define SPRITE_EXTWIDTH(n)   (vic_registers[0x57] & (1 << (n)))
+#define SPRITE_EXTWIDTH(n)   (SPRITE_16COLOR(n) | (vic_registers[0x57] & (1 << (n))))
 #define SPRITE_EXTHEIGHT(n)  (vic_registers[0x55] & (1 << (n)))
 #define SPRITE_BITPLANE_ENABLE(n)  (((REG_SPRBPMEN_4_7) << 4 | REG_SPRBPMEN_0_3) & (1 << (n)))
 #define SPRITE_16BITPOINTER  (vic_registers[0x6E] & 0x80)

--- a/targets/mega65/vic4.h
+++ b/targets/mega65/vic4.h
@@ -25,16 +25,26 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 #define VIC_BAD_IOMODE	2
 #define VIC4_IOMODE	3
 
-#define SCREEN_WIDTH		      800
-#define SCREEN_HEIGHT_NTSC    506
-#define SCREEN_HEIGHT_PAL     603
-#define SCREEN_HEIGHT	      SCREEN_HEIGHT_PAL
-#define NTSC_PHYSICAL_RASTERS 526
-#define PAL_PHYSICAL_RASTERS  624
-#define FRAME_H_FRONT         0
-#define RASTER_CORRECTION     3
-#define DISPLAY_FETCH_START   719
-#define VIC4_BLINK_INTERVAL   25
+//
+// Output window is fixed at 800x600 to support MegaPHONE, PAL-MEGA65
+// and NTSC_MEGA65 modes. Internally, the VIC-IV chip draws 800-pixel
+// wide buffers and traverses up to 526/624 physical rasters, as we do here.  
+// The user can select a clipped borders view (called "normal borders") which shows 
+// the real visible resolution of PAL (720x576) or NSTC(720x480).
+//
+
+#define SCREEN_WIDTH		              800
+#define SCREEN_HEIGHT                 600
+#define PHYSICAL_RASTERS_DEFAULT      PHYSICAL_RASTERS_NTSC
+#define SCREEN_HEIGHT_VISIBLE_DEFAULT SCREEN_HEIGHT_VISIBLE_NTSC
+#define SCREEN_HEIGHT_VISIBLE_NTSC    480
+#define SCREEN_HEIGHT_VISIBLE_PAL     576
+#define PHYSICAL_RASTERS_NTSC         526
+#define PHYSICAL_RASTERS_PAL          624
+
+#define FRAME_H_FRONT                  0
+#define RASTER_CORRECTION              3
+#define VIC4_BLINK_INTERVAL            25
 
 // Register defines 
 // 

--- a/targets/mega65/vic4.h
+++ b/targets/mega65/vic4.h
@@ -82,6 +82,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 #define REG_TEXTXPOS_U4     (vic_registers[0x4D] & 0xF)
 #define REG_TEXTYPOS        (vic_registers[0x4E])
 #define REG_TEXTYPOS_U4     (vic_registers[0x4F] & 0xF)
+#define REG_XPOS            (vic_registers[0x51])
+#define REG_XPOS_U6         (vic_registers[0x50] & 0x3F)
 #define REG_16BITCHARSET    (vic_registers[0x54] & 1)
 #define REG_FCLRLO          (vic_registers[0x54] & 2)
 #define REG_FCLRHI          (vic_registers[0x54] & 4)
@@ -174,12 +176,17 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
                                  vic_registers[(basereg)] = (Uint8) ((Uint16)(x)) & 0x00FF;
 #define SET_12BIT_REG(basereg,x) vic_registers[((basereg)+1)] = (Uint8) ((((Uint16)(x)) & 0xF00) >> 8); \
                                  vic_registers[(basereg)] = (Uint8) ((Uint16)(x)) & 0x00FF;
+#define SET_14BIT_REG(basereg,x) vic_registers[((basereg)+1)] = (Uint8) ((((Uint16)(x)) & 0x3F00) >> 8); \
+                                 vic_registers[(basereg)] = (Uint8) ((Uint16)(x)) & 0x00FF;      
+#define SET_14BIT_REGI(basereg,x) vic_registers[(basereg)] = (Uint8) ((((Uint16)(x)) & 0x3F00) >> 8); \
+                                  vic_registers[((basereg)+1)] = (Uint8) ((Uint16)(x)) & 0x00FF;                           
 #define SET_16BIT_REG(basereg,x) vic_registers[((basereg) + 1)] = (Uint8) ((((Uint16)(x)) & 0xFF00) >> 8); \
                                  vic_registers[(basereg)]= ((Uint16)(x)) & 0x00FF;
 
 // 11-bit registers
 
 #define SET_PHYSICAL_RASTER(x) SET_11BIT_REG(0x52, (x))
+#define SET_RASTER_XPOS(x)     SET_14BIT_REGI(0x50, (x))
 
 // 12-bit registers
 

--- a/xemu/emutools.h
+++ b/xemu/emutools.h
@@ -177,6 +177,8 @@ extern int xemu_change_display_mode(
 	Uint32 pixel_format,
 	int locked_texture_update
 );
+extern void xemu_set_viewport(int left, int top, int right, int bottom, int adjust_window_size);
+extern void xemu_clear_viewport();
 extern int xemu_set_icon_from_xpm ( char *xpm[] );
 extern void xemu_timekeeping_start ( void );
 extern void xemu_render_dummy_frame ( Uint32 colour, int texture_x_size, int texture_y_size );

--- a/xemu/emutools.h
+++ b/xemu/emutools.h
@@ -170,6 +170,13 @@ extern int xemu_post_init (
         int locked_texture_update,              // use locked texture method [non zero], or malloc'ed stuff [zero]. NOTE: locked access doesn't allow to _READ_ pixels and you must fill ALL pixels!
         void (*shutdown_callback)(void)         // callback function called on exit (can be nULL to not have any emulator specific stuff)
 );
+extern int xemu_change_display_mode(
+	int texture_x_size, int texture_y_size,	
+	int logical_x_size, int logical_y_size,	
+	int win_x_size, int win_y_size,
+	Uint32 pixel_format,
+	int locked_texture_update
+);
 extern int xemu_set_icon_from_xpm ( char *xpm[] );
 extern void xemu_timekeeping_start ( void );
 extern void xemu_render_dummy_frame ( Uint32 colour, int texture_x_size, int texture_y_size );


### PR DESCRIPTION

* NTSC/PAL video mode select (no timings yet).
* Bilinear filtering for a better picture quality.
* VIC-II bank  logic fixes.
* 16-color sprite mode implies 16-pixel wide sprites (SPRX64EN will be set to ENABLE)