### PR TITLE
Fix #146 MacOs Compile problem (on branch hmw)

### DIFF
--- a/targets/mega65/fat32.h
+++ b/targets/mega65/fat32.h
@@ -71,6 +71,7 @@ extern void   mfat_init     ( mfat_io_callback_func_t reader, mfat_io_callback_f
 extern int    mfat_init_mbr ( void     );
 extern int    mfat_use_part ( int part );
 
+extern int    mfat_flush_fat_cache ( void );
 extern int    mfat_normalize_name ( char *d, const char *s );
 extern int    mfat_fatize_name    ( char *d, const char *s );
 extern int    mfat_read_directory ( mfat_dirent_t *p, int type_filter );

--- a/xemu/arch-sys.h
+++ b/xemu/arch-sys.h
@@ -63,6 +63,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 #	define	XEMU_ARCH_UNIX
 #	define	XEMU_ARCH_NAME	"osx"
 #	define	XEMU_SLEEP_IS_NANOSLEEP
+#	define	_XOPEN_SOURCE	100
 #elif	defined(__unix__) || defined(__unix) || defined(__linux__) || defined(__linux)
 #	define	XEMU_ARCH_UNIX
 #	if	defined(__linux__) || defined(__linux)


### PR DESCRIPTION
Fixes problem with compiling on a clean install of macOS Catalina. See #146 for description of the problem.

The single-line fix to #144 was cherry-picked into this get the compile to this point.

This fix is enough to get the compile to complete successfully and get a working binary.