### PR TITLE
Fix #232 #255 - Added char_fetch_offset to facilitate RRB Y positioning offsets

### DIFF
--- a/targets/mega65/vic4.c
+++ b/targets/mega65/vic4.c
@@ -1137,6 +1137,7 @@ static void vic4_render_char_raster ( void )
 		current_pixel += (CHARGEN_X_START - border_x_left);
 		xcounter += (CHARGEN_X_START - border_x_left);
 		const int xcounter_start = xcounter;
+		Uint8 char_fetch_offset = 0;
 		// Chargen starts here.
 		while (line_char_index < REG_CHRCOUNT) {
 			Uint16 color_data = *(colour_ram_current_ptr++);
@@ -1151,7 +1152,7 @@ static void vic4_render_char_raster ( void )
 					xcounter = xcounter_start + (char_value & 0x3FF) * (REG_H640 ? 1 : 2);
 					current_pixel = pixel_raster_start + xcounter;
 					line_char_index++;
-
+					char_fetch_offset = char_value >> 13;
 					if (SXA_VERTICAL_FLIP(color_data))
 						enable_bg_paint = 0;
 					continue;
@@ -1178,9 +1179,9 @@ static void vic4_render_char_raster ( void )
 				char_byte = reverse_byte_table[char_byte];	// LGB: I killed the function, and type-conv, as char_byte is byte, OK to index as-is
 			// Render character cell row
 			if (SXA_4BIT_PER_PIXEL(color_data)) {	// 16-color character
-				vic4_render_16color_char_row(main_ram + (((char_id * 64) + (sel_char_row * 8) ) & 0x7FFFF), glyph_width, palette[char_bgcolor], palette + (color_data & 0xF0));
+				vic4_render_16color_char_row(main_ram + (((char_id * 64) + ((sel_char_row + char_fetch_offset) * 8) ) & 0x7FFFF), glyph_width, palette[char_bgcolor], palette + (color_data & 0xF0));
 			} else if (CHAR_IS256_COLOR(char_id)) {	// 256-color character
-				vic4_render_fullcolor_char_row(main_ram + (((char_id * 64) + (sel_char_row * 8) ) & 0x7FFFF), 8);
+				vic4_render_fullcolor_char_row(main_ram + (((char_id * 64) + ((sel_char_row + char_fetch_offset) * 8) ) & 0x7FFFF), 8);
 			} else if ((REG_MCM && (char_fgcolor & 8)) || (REG_MCM && REG_BMM)) {	// Multicolor character
 				if (REG_BMM) {
 					const Uint8 color_source[4] = {


### PR DESCRIPTION


[vic4tests.zip](https://github.com/lgblgblgb/xemu/files/6586515/vic4tests.zip)

See new test under 16 Color Char Mode -> RRB Ypositioning 40 column

Change is made for Full color and 16 color char modes, I'm not sure this is even available in Mono or MC on real hardware, will check at a a later date. This fix should account for the majority of this features usage

