### PR TITLE
MEGA65 VIC-IV fix for horizontally tiled sprites

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,0 @@
-make ARCH=win64
-mv ./build/bin/xmega65.win64 ./build/bin/xmega65.exe
-

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+make ARCH=win64
+mv ./build/bin/xmega65.win64 ./build/bin/xmega65.exe
+

--- a/targets/mega65/vic4.c
+++ b/targets/mega65/vic4.c
@@ -1162,6 +1162,7 @@ static void vic4_render_char_raster ( void )
 		xcounter += (CHARGEN_X_START - border_x_left);
 		const int xcounter_start = xcounter;
 		Uint8 char_fetch_offset = 0;
+		int ncm_alt_palette = 0;
 		// Chargen starts here.
 		while (line_char_index < REG_CHRCOUNT) {
 			Uint16 color_data = *(colour_ram_current_ptr++);
@@ -1177,6 +1178,10 @@ static void vic4_render_char_raster ( void )
 					char_fetch_offset = char_value >> 13;
 					if (SXA_VERTICAL_FLIP(color_data))
 						enable_bg_paint = 0;
+					if (SXA_ATTR_BOLD(color_data) && SXA_ATTR_REVERSE(color_data) && !REG_VICIII_ATTRIBS)
+						ncm_alt_palette = 1;
+					else 
+					    ncm_alt_palette = 0;
 					continue;
 				}
 			}
@@ -1193,7 +1198,7 @@ static void vic4_render_char_raster ( void )
 				sel_char_row = 7 - char_row;
 			// Render character cell row
 			if (SXA_4BIT_PER_PIXEL(color_data)) {	// 16-color character
-				vic4_render_16color_char_row(main_ram + (((char_id * 64) + ((sel_char_row + char_fetch_offset) * 8) ) & 0x7FFFF), glyph_width, palette[char_bgcolor], palette + (color_data & 0xF0), SXA_HORIZONTAL_FLIP(color_data));
+				vic4_render_16color_char_row(main_ram + (((char_id * 64) + ((sel_char_row + char_fetch_offset) * 8) ) & 0x7FFFF), glyph_width, palette[char_bgcolor], (ncm_alt_palette ? altpalette : palette) + (color_data & 0xF0), SXA_HORIZONTAL_FLIP(color_data));
 			} else if (CHAR_IS256_COLOR(char_id)) {	// 256-color character
 				// fgcolor in case of FCM should mean colour index $FF
 				// FIXME: check if the passed palette[char_fgcolor] is correct or another index should be used for that $FF colour stuff

--- a/targets/mega65/vic4.c
+++ b/targets/mega65/vic4.c
@@ -853,22 +853,24 @@ static XEMU_INLINE void vic4_draw_sprite_row_16color( int sprnum, int x_display_
 	// in 16 colour sprite mode, sprite colour register gives the transparent colour index
 	// We always use the lower 4 bit only at this very specific case, that's the reason for SPRITE_COLOR_4BIT() macro and not SPRITE_COLOR() [which can be 4/8 bit depending on curretn VIC mode)
 	const Uint8 transparency_palette_index = SPRITE_COLOR_4BIT(sprnum);
-	for (int byte = 0; byte < totalBytes; byte++) {
-		const Uint8 c0 = (*(row_data_ptr + byte)) >> 4;
-		const Uint8 c1 = (*(row_data_ptr + byte)) & 0xF;
-		for (int p = 0; p < xscale && x_display_pos < border_x_right; p++, x_display_pos++) {
-			if (c0 != transparency_palette_index && x_display_pos >= border_x_left && (
-				!SPRITE_IS_BACK(sprnum) || (SPRITE_IS_BACK(sprnum) && !is_fg[x_display_pos])
-			))
-				*(pixel_raster_start + x_display_pos) = pal16[c0];
+	do {
+		for (int byte = 0; byte < totalBytes; byte++) {
+			const Uint8 c0 = (*(row_data_ptr + byte)) >> 4;
+			const Uint8 c1 = (*(row_data_ptr + byte)) & 0xF;
+			for (int p = 0; p < xscale && x_display_pos < border_x_right; p++, x_display_pos++) {
+				if (c0 != transparency_palette_index && x_display_pos >= border_x_left && (
+					!SPRITE_IS_BACK(sprnum) || (SPRITE_IS_BACK(sprnum) && !is_fg[x_display_pos])
+				))
+					*(pixel_raster_start + x_display_pos) = pal16[c0];
+			}
+			for (int p = 0; p < xscale && x_display_pos < border_x_right; p++, x_display_pos++) {
+				if (c1 != transparency_palette_index && x_display_pos >= border_x_left && (
+					!SPRITE_IS_BACK(sprnum) || (SPRITE_IS_BACK(sprnum) && !is_fg[x_display_pos])
+				))
+					*(pixel_raster_start + x_display_pos) = pal16[c1];
+			}
 		}
-		for (int p = 0; p < xscale && x_display_pos < border_x_right; p++, x_display_pos++) {
-			if (c1 != transparency_palette_index && x_display_pos >= border_x_left && (
-				!SPRITE_IS_BACK(sprnum) || (SPRITE_IS_BACK(sprnum) && !is_fg[x_display_pos])
-			))
-				*(pixel_raster_start + x_display_pos) = pal16[c1];
-		}
-	}
+	} while ((REG_SPRTILEN & (1 << sprnum)) && x_display_pos < border_x_right);
 }
 
 

--- a/targets/mega65/vic4.h
+++ b/targets/mega65/vic4.h
@@ -84,6 +84,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 #define REG_BBRDPOS_U4			(vic_registers[0x4B] & 0xF)
 #define REG_TEXTXPOS			(vic_registers[0x4C])
 #define REG_TEXTXPOS_U4			(vic_registers[0x4D] & 0xF)
+#define REG_SPRTILEN			((vic_registers[0x4D] & 0xF0) >> 4 | (vic_registers[0x4F] & 0xF0))
 #define REG_TEXTYPOS			(vic_registers[0x4E])
 #define REG_TEXTYPOS_U4			(vic_registers[0x4F] & 0xF)
 #define REG_XPOS			(vic_registers[0x51])

--- a/targets/mega65/vic4.h
+++ b/targets/mega65/vic4.h
@@ -172,6 +172,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 #define SXA_GOTO_X(cw)			((cw) & 0x1000)
 #define SXA_4BIT_PER_PIXEL(cw)		((cw) & 0x0800)
 #define SXA_TRIM_RIGHT_BIT3(cw)		((cw) & 0x0400)
+#define SXA_ATTR_BOLD(cw)		((cw) & 0x0040)
+#define SXA_ATTR_REVERSE(cw)		((cw) & 0x0020)
 //FIXME: this last one was bad, and also, seems to be not used?
 //#define SXA_TRIM_TOP_BOTTOM(cw)	(((cw) & 0x0300) >> 8)
 


### PR DESCRIPTION
This feature was not present, see old vic4test (A-C)

![image](https://user-images.githubusercontent.com/4640763/121096040-527a8280-c7e9-11eb-836f-ad946eb09cc9.png)

feel free to request changes as ever :) And please squash merge to get rid of the horrid history. I'll take a fresh fork next time!