### PR TITLE
Fix VICIII Attribute Emulation + blink phase interval

### DIFF
--- a/targets/mega65/vic4.h
+++ b/targets/mega65/vic4.h
@@ -49,7 +49,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 #define PHYSICAL_RASTERS_PAL		624
 #define FRAME_H_FRONT			0
 #define RASTER_CORRECTION		3
-#define VIC4_BLINK_INTERVAL		25
+#define VIC4_BLINK_INTERVAL		30
 
 // Register defines
 //


### PR DESCRIPTION
This also fixes blink interval to honour VHDL/hardware specs (30 vs 25). Address https://github.com/lgblgblgb/xemu/issues/281

**BEFORE**

https://user-images.githubusercontent.com/4740613/125117848-2e021680-e0c5-11eb-8501-bf19b2a66f94.mp4

**FIX**

https://user-images.githubusercontent.com/4740613/125117987-6b66a400-e0c5-11eb-9327-71a86b8079a3.mp4

**Hardware**

https://user-images.githubusercontent.com/4740613/125118929-c4830780-e0c6-11eb-933c-9185cf0083f7.mp4

