### PR TITLE
rom: Fix documentation regarding how to fetch roms

### DIFF
--- a/rom/README
+++ b/rom/README
@@ -16,7 +16,7 @@ of hacky, "replacement" solution for the problem ...
 
 You can also use Makefile to download the needed files from Internet:
 
-make roms
+make fetchroms
 
 (issued from the root directory of the project)
 


### PR DESCRIPTION
Replace `make roms` with `make fetchroms`

