### PR TITLE
MEGA65: Sprite MSB and superMSB X/Y support V400 rendering, V400/H640 position, SPRYADJ support #320

### DIFF
--- a/targets/mega65/vic4.c
+++ b/targets/mega65/vic4.c
@@ -1,7 +1,7 @@
 /* A work-in-progess MEGA65 (Commodore 65 clone origins) emulator
    Part of the Xemu project, please visit: https://github.com/lgblgblgb/xemu
    Copyright (C)2016-2022 LGB (Gábor Lénárt) <lgblgblgb@gmail.com>
-   Copyright (C)2020-2021 Hernán Di Pietro <hernan.di.pietro@gmail.com>
+   Copyright (C)2020-2022 Hernán Di Pietro <hernan.di.pietro@gmail.com>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -74,7 +74,6 @@ static Uint8 vic_pixel_readback_result[4];
 static Uint8 vic_color_register_mask = 0xFF;
 static Uint32 *used_palette;					// normally the same value as "palette" from vic4_palette.c but GOTOX RRB token can modify this! So this should be used
 static int EFFECTIVE_V400;
-static Uint8 sprite_y_adjust = 0;
 
 // TODO: not really implemented just here ...
 static int etherbuffer_is_io_mapped = 0;
@@ -325,6 +324,10 @@ static void vic4_update_vertical_borders( void )
 		}
 		SET_CHARGEN_Y_START(RASTER_CORRECTION + SINGLE_TOP_BORDER_400 - (2 * vicii_first_raster) - 6 + (REG_VIC2_YSCROLL * 2));
 	}
+
+	// This offset is present in recent versions of VIC-IV VHDL
+	SET_CHARGEN_X_START(CHARGEN_X_START - 1);
+
 	DEBUGPRINT("VIC4: set border top=%d, bottom=%d, textypos=%d, display_row_count=%d vic_ii_first_raster=%d EFFECTIVE_V400=%d REG_V400=%d" NL, BORDER_Y_TOP, BORDER_Y_BOTTOM,
 		CHARGEN_Y_START, display_row_count, vicii_first_raster, EFFECTIVE_V400, REG_V400);
 }
@@ -396,7 +399,7 @@ void vic4_open_frame_access ( void )
 			max_rasters = PHYSICAL_RASTERS_NTSC;
 			visible_area_height = SCREEN_HEIGHT_VISIBLE_NTSC;
 			vicii_first_raster = 7;
-			sprite_y_adjust = 24;
+			REG_SPRITE_Y_ADJUST = 24;
 		} else {
 			// --- PAL ---
 			new_name = PAL_STD_NAME;
@@ -405,7 +408,7 @@ void vic4_open_frame_access ( void )
 			max_rasters = PHYSICAL_RASTERS_PAL;
 			visible_area_height = SCREEN_HEIGHT_VISIBLE_PAL;
 			vicii_first_raster = 0;
-			sprite_y_adjust = 0;
+			REG_SPRITE_Y_ADJUST = 0;
 		}
 		DEBUGPRINT("VIC: switching video standard from %s to %s (1MHz line cycle count is %f, frame time is %dusec, max raster is %d, visible area height is %d)" NL, videostd_name, new_name, videostd_1mhz_cycles_per_scanline, videostd_frametime, max_rasters, visible_area_height);
 		videostd_name = new_name;
@@ -1062,11 +1065,15 @@ static XEMU_INLINE void vic4_do_sprites ( void )
 	const int reg_tiling = REG_SPRTILEN;
 	for (int sprnum = 7; sprnum >= 0; sprnum--) {
 		if (REG_SPRITE_ENABLE & (1 << sprnum)) {
+			const int y_adjust = SPRITE_V400(sprnum) ? 0 : (REG_SPRITE_Y_ADJUST - 2);
 			const int spriteHeight = SPRITE_EXTHEIGHT(sprnum) ? REG_SPRHGHT : 21;
-			const int x_display_pos = SPRITE_FIRST_X + (SPRITE_POS_X(sprnum) * (REG_SPR640 ? 1 : 2));	// in display units
-			const int y_logical_pos = SPRITE_POS_Y(sprnum) - sprite_y_adjust + ( (EFFECTIVE_V400 ? 1 : 2));	// in logical units
+			const int x_display_pos = (REG_SPR640 ? 1 : 2) * SPRITE_POS_X(sprnum) + (REG_SPR640 ? 1 : SPRITE_FIRST_X);
+			const int y_display_pos = ((SPRITE_V400(sprnum) ? 1 : 2) * (SPRITE_POS_Y(sprnum) - y_adjust)) ;
 
-			int sprite_row_in_raster = logical_raster - y_logical_pos;
+			int sprite_row_in_raster = ycounter - y_display_pos;
+
+			if (!SPRITE_V400(sprnum))
+				sprite_row_in_raster = sprite_row_in_raster >> 1;
 
 			if (SPRITE_VERT_2X(sprnum))
 				sprite_row_in_raster = sprite_row_in_raster >> 1;
@@ -1501,16 +1508,19 @@ int vic4_render_scanline ( void )
 			if (ycounter < CHARGEN_Y_START)
 				while (xcounter++ < border_x_right)
 					*current_pixel++ = palette[REG_SCREEN_COLOR];
-			if (ycounter < BORDER_Y_BOTTOM)
-				vic4_do_sprites();
-			// for (int i = 0; i < TEXTURE_WIDTH - border_x_right; i++, current_pixel++)
-			//	*current_pixel = palette[REG_SCREEN_COLOR];
 		}
 		for (Uint32 *p = pixel_raster_start; p < pixel_raster_start + border_x_left; p++)
 			*p = palette[REG_BORDER_COLOR];
 		for (Uint32 *p = current_pixel; p < current_pixel + border_x_right; p++)
 			*p = palette[REG_BORDER_COLOR];
 	}
+	// Sprites can be displayed on V200/V400 independently of char generator, so
+	// this must be outside of the main loop to avoid being affected by double-scan
+
+	if (XEMU_LIKELY(REG_DISPLAYENABLE) && (ycounter >= BORDER_Y_TOP && ycounter < BORDER_Y_BOTTOM)) {
+		vic4_do_sprites();
+	}
+
 	ycounter++;
 	// End of frame?
 	if (ycounter == max_rasters) {

--- a/targets/mega65/vic4.h
+++ b/targets/mega65/vic4.h
@@ -1,7 +1,7 @@
 /* A work-in-progess MEGA65 (Commodore 65 clone origins) emulator
    Part of the Xemu project, please visit: https://github.com/lgblgblgb/xemu
    Copyright (C)2016-2022 LGB (Gábor Lénárt) <lgblgblgb@gmail.com>
-   Copyright (C)2020-2021 Hernán Di Pietro <hernan.di.pietro@gmail.com>
+   Copyright (C)2020-2022 Hernán Di Pietro <hernan.di.pietro@gmail.com>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -116,6 +116,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 #define REG_SPRPTR_B0			vic_registers[0x6C]
 #define REG_SPRPTR_B1			vic_registers[0x6D]
 #define REG_SPRPTR_B2			(vic_registers[0x6E] & 0x7F)
+#define REG_SPRITE_Y_ADJUST		vic_registers[0x72]
 //#define REG_SCREEN_ROWS		vic_registers[0x7B]
 //#define REG_PAL_RED_BASE		(vic_registers[0x100])
 //#define REG_PAL_GREEN_BASE		(vic_registers[0x200])
@@ -139,8 +140,12 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 #define COLOUR_RAM_OFFSET		((((Uint16)REG_COLPTR) | (REG_COLPTR_MSB) << 8))
 //#define IS_NTSC_MODE			(videostd_id)
 //#define SCREEN_STEP			(((Uint16)REG_LINESTEP) | (REG_LINESTEP_U8) << 8)
-#define SPRITE_POS_Y(n)			(vic_registers[1 + (n)*2])
-#define SPRITE_POS_X(n)			(((Uint16)vic_registers[(n)*2]) | ( (vic_registers[0x10] & (1 << (n)) ? 0x100 : 0)))
+#define SPRITE_POS_Y(n)			(((Uint16)vic_registers[1 + (n)*2]) | \
+								( (vic_registers[0x77] & (1 << (n)) ? 0x100 : 0)) | \
+								( (vic_registers[0x78] & (1 << (n)) ? 0x200 : 0)))
+#define SPRITE_POS_X(n)			(((Uint16)vic_registers[(n)*2]) | \
+								( (vic_registers[0x10] & (1 << (n)) ? 0x100 : 0)) | \
+								( (vic_registers[0x5f] & (1 << (n)) ? 0x200 : 0)))
 #define SPRITE_COLOR(n)			(vic_registers[0x27+(n)] & vic_color_register_mask)
 #define SPRITE_COLOR_4BIT(n)		(vic_registers[0x27+(n)] & 0xF)
 #define SPRITE_MULTICOLOR_1		(vic_registers[0x25] & vic_color_register_mask)
@@ -154,6 +159,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 #define SPRITE_EXTHEIGHT(n)		(vic_registers[0x55] & (1 << (n)))
 #define SPRITE_BITPLANE_ENABLE(n)	(((REG_SPRBPMEN_4_7) << 4 | REG_SPRBPMEN_0_3) & (1 << (n)))
 #define SPRITE_16BITPOINTER		(vic_registers[0x6E] & 0x80)
+#define SPRITE_V400(n)			(vic_registers[0x76] & (1 << (n)))
 //#define TEXT_MODE			(!REG_BMM)
 //#define HIRES_BITMAP_MODE		(REG_BMM & !REG_MCM & !REG_EBM)
 //#define MULTICOLOR_BITMAP_MODE	(REG_BMM & REG_MCM & !REG_EBM)


### PR DESCRIPTION
* Implement SPRYADJ for NTSC/PAL
* MSBs and Super-MSBs for X/Y pos in V400/H640 sprite modes
* Fixed Character-generator 1px offset
* Correct SPRV400 rendering in V400-mode, partially working in V200 mode.
* Sprite X/Y default offsets fixed for 320/640 widths.
