### PR TITLE
MEGA65: Upper 4 bits fgcolor NCM fix #328

### DIFF
--- a/targets/mega65/vic4.c
+++ b/targets/mega65/vic4.c
@@ -1381,7 +1381,7 @@ static XEMU_INLINE void vic4_render_char_raster ( void )
 					main_ram + (((char_id * 64) + ((sel_char_row + char_fetch_offset) * 8)) & 0x7FFFF),
 					16 - glyph_trim,
 					used_palette[char_bgcolor],		// bg SDL colour
-					used_palette[char_fgcolor],		// fg SDL colour
+					(used_palette + (color_data & 0xF0))[char_fgcolor],		// fg SDL colour
 					used_palette + (color_data & 0xF0),	// palette(16) pointer
 					SXA_HORIZONTAL_FLIP(color_data)		// hflip?
 				);


### PR DESCRIPTION
Respecting palette(16) pointer in case fgcolor is selected

This fix selects the correct NCM 16col palette in case fgcolor is selected for a pixel.
