### PR TITLE
Fixed Compiler Warnings

### DIFF
--- a/targets/ep128/epnet.c
+++ b/targets/ep128/epnet.c
@@ -177,7 +177,6 @@ static int net_thread ( void *ptr )
 	while (SDL_AtomicGet(&thread_can_go) != 0) {
 		int activity = 0;
 		for (int sn = 0; sn < 8; sn++) {
-			Uint8 buffer[0x20000];
 			struct net_task_data_st data;
 			/* LOCK BEGINS */
 			if (SDL_AtomicTryLock(&net_thread_tasks[sn].lock) == SDL_FALSE) {
@@ -329,7 +328,7 @@ static Uint8 read_reg ( int addr )
 				data = wregs[addr];	// access of reg Sn_BASE + 0x30 stored the needed value here!
 				break;
 			default:
-				DEBUGPRINT("EPNET: W5300: reading unemulated SOCKET register $%03X S-%d/$%02X" NL, addr, sn, sn_reg);
+				DEBUGPRINT("EPNET: W5300: writing unemulated SOCKET register $%03X S-%d/$%02X/$%02X" NL, addr, sn, sn_base, sn_reg);
 				data = wregs[addr];	// no idea, just pass back the value ...
 				break;
 		}
@@ -526,7 +525,7 @@ static void write_reg ( int addr, Uint8 data )
 				RX_FIFO_FILL(sn, (wregs[addr - 1] << 8) | data);	// access of reg Sn_BASE + 0x30 stored the needed value we're referencing here!
 				break;
 			default:
-				DEBUGPRINT("EPNET: W5300: writing unemulated SOCKET register $%03X S-%d/$%02X" NL, addr, sn, sn_reg);
+				DEBUGPRINT("EPNET: W5300: writing unemulated SOCKET register $%03X S-%d/$%02X/$%02X" NL, addr, sn, sn_base, sn_reg);
 				wregs[addr] = data;
 				break;
 		}

--- a/targets/mega65/hdos.c
+++ b/targets/mega65/hdos.c
@@ -840,7 +840,6 @@ void hdos_leave ( const Uint8 func_no )
 		// Let's do a local copy of the successfully selected name via hyppo (we know this by knowing that C flag is set by hyppo)
 		// FIXME: in case of error, is setname buffer modified?
 		// FIXME: is only Y used for _page_ and X ignored, also is tranfer area addr is really modified as a "side effect"?
-		char setnam_current[sizeof hdos.setname_fn];
 		// FIXME: copy routine should not fail ever if hyppo already accepted!
 		if (copy_string_from_user(hdos.setname_fn, sizeof hdos.setname_fn, hdos.in_x + (hdos.in_y << 8)) >= 0)
 			// hdos.transfer_area_address = hdos.in_y << 8;	// WTF? setname has X/Y as input!


### PR DESCRIPTION
Removed some unused variables.
Added one unused variable to debug print since it may be useful.

