### PR TITLE
CORE/SDL: Enabled SDL_Quit() in shutdown_emulator()

### DIFF
--- a/xemu/emutools.c
+++ b/xemu/emutools.c
@@ -593,7 +593,9 @@ static void shutdown_emulator ( void )
 	}
 	// It seems, calling SQL_Quit() at least on Windows causes "segfault".
 	// Not sure why, but to be safe, I just skip calling it :(
-	//SDL_Quit();
+#ifndef XEMU_ARCH_WIN
+	SDL_Quit();
+#endif
 }
 
 


### PR DESCRIPTION
Enabling the call to SDL_Quit() fixes the "does not exit"
bug in Haiku.