### PR TITLE
Sprite bank (Fix #342)

### DIFF
--- a/targets/mega65/vic4.c
+++ b/targets/mega65/vic4.c
@@ -1114,7 +1114,7 @@ static XEMU_INLINE void vic4_do_sprites ( void )
 				const Uint8 *sprite_data_pointer = main_ram + sprite_pointer_addr + sprnum * ((SPRITE_16BITPOINTER >> 7) + 1);
 				const Uint32 sprite_data_addr = SPRITE_16BITPOINTER ?
 					64 * ((*(sprite_data_pointer + 1) << 8) | (*sprite_data_pointer))
-					: ((64 * (*sprite_data_pointer)) | ( ((~last_dd00_bits) & 0x3)) << 14);
+					: ((64 * (*sprite_data_pointer)) | (SPRITE_POINTER_ADDR & 0xC000)); // Use bits 14-15 (this can be set from $DD00 if HOTREG is ENABLED)
 
 				//DEBUGPRINT("VIC: Sprite %d data at $%08X " NL, sprnum, sprite_data_addr);
 				const Uint8 *sprite_data = main_ram + sprite_data_addr;


### PR DESCRIPTION
This will fix VIC-II bank selection for sprite data fetch.

This is the bad behavior:  first 4 examples are using VIC-II banking (correct) but later failed due to our previous assumption that bits 14/15 always came from $DD00 !

https://user-images.githubusercontent.com/4740613/187753149-8f80f03f-3af3-4887-829a-ba22a0077e30.mp4

This is the fixed run.  (Compliant with MEGA65 hardware).


https://user-images.githubusercontent.com/4740613/187753395-183d4457-6fc2-4c45-88a9-a43c561095ee.mp4


