### PR TITLE
MEGA65: Update vic4.c for fix for transparency issue

### DIFF
--- a/targets/mega65/vic4.c
+++ b/targets/mega65/vic4.c
@@ -1439,6 +1439,8 @@ static XEMU_INLINE void vic4_render_char_raster ( void )
 						char_fetch_offset = -char_fetch_offset;
 					if (SXA_VERTICAL_FLIP(color_data))
 						enable_bg_paint = 0;
+					else
+						enable_bg_paint = 1;
 					if (SXA_ATTR_BOLD(color_data) && SXA_ATTR_REVERSE(color_data) && !REG_VICIII_ATTRIBS)
 						used_palette = altpalette;	// use the alternate palette from now in the scanline
 					else


### PR DESCRIPTION
this fixes issue #407 

when GOTOX bit is set you need to set / clear transparency based on colorram0-bit7

